### PR TITLE
Fix writing and typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ main language. Sending me corrections  is not the only way you can help
 Full disclosure
 ------------------
 
-The novel is roughly completed (that is, it's got an ending, it will
+The novel is roughly completed (that is, while it's got an ending, it will
 actually never be finished since it might evolve in time) and is
 published in Amazon.com and the rest of the Amazon shops. Since all
 your contributions will be here, in the repo, they are obviously

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Manuel the Marvelous Mechanical Man, the novel
 [![Join the chat at https://gitter.im/JJ/hoborg](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/JJ/hoborg?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 This is the source for an ur-[dieselpunk](https://es.wikipedia.org/wiki/Dieselpunk) novel with a Spanish-created robot hobo in a balkanized
-United States of America at the beginning of al alternative XXth century. 
+United States of America at the beginning of an alternative XXth century. 
 
 The novel is [available in Amazon.com for a dollar](https://www.amazon.com/dp/B00ED084BK/ref=as_li_ss_til?tag=perltutobyjjmere&camp=0&creative=0&linkCode=as4&creativeASIN=B00ED084BK&adid=1HG3N2ZNW9C40MFDC9WP&). 
 
@@ -20,7 +20,7 @@ Plot outline
 
 After the United States of America is defeated by a technologically superior Cuba and
 Spain, Florida becomes an independent multiracial socialist state
-which is inmediately at war with the (now diminished) America. 
+which is immediately at war with the (now diminished) America. 
 
 A North-American Pinkerton agent is sent there to recover a
 *mechanical man* that has been seen in a circus doing gigs from
@@ -58,8 +58,8 @@ Full disclosure
 ------------------
 
 The novel is roughly completed (that is, it's got an ending, it will
-actually never be finished since it might evolve in time) and
-published it in Amazon.com and the rest of the Amazon shops. Since all
+actually never be finished since it might evolve in time) and is
+published in Amazon.com and the rest of the Amazon shops. Since all
 your contributions will be here, in the repo, they are obviously
 acknowledged, but I'll acknowledge it also in the prologue itself and,
 if I earn enough to be able to physically print it and mail it, will
@@ -71,20 +71,20 @@ Start reading and participating
 
 Just go to [the novel](text/text.md). You can also
 [read about the characters](text/characters.md), although doing so
-might result in spoilerage, or about the
+might result in spoiling the story for yourself, or about the
 [geography of the Republic of Florida](text/geography.md). 
 
 Thanks
 ------
 
-Many thanks to those that have provided
+Many thanks to those who have provided
 [fixes and suggestions](https://github.com/JJ/hoborg/pulls?q=is%3Apr+is%3Aclosed)
 to the text: [`yarikoptic`](https://github.com/yarikoptic) and [`quentessential`](http://github.com/quentessential).
 
 How this can help you write your own novel
 -----------------------
 
-Read the [installation instructions](INSTALL.md) to get your very own novel going in Github. They are long-ish, but may be worth the while. 
+Read the [installation instructions](INSTALL.md) to get your very own novel going in Github. They are long-ish, but may be worth your while. 
 
 Navigating the repository
 ---------------------------------
@@ -93,8 +93,8 @@ You already know the [text](text/README.md) directory, which contains
 the novel text itself as well as scraps we might need for
 later. [resources](resources/README.md) contains HTML templates,
 images and other non-text stuff. [apps](apps/README.md) includes
-conversion scripts and other mainly Perl scripts I use for managing
-this. [Text-Hoborg](Text-Hoborg/README) contains a Perl module that is
+conversion scripts and other scripts I use for managing
+this, mainly written in Perl. [Text-Hoborg](Text-Hoborg/README) contains a Perl module that is
 used for testing and continuous integration and might eventually
 contain the novel itself and be released that way. 
 
@@ -102,5 +102,5 @@ Get in touch
 ---------------
 
 If you have some issue related to the novel, [use the GitHub
-issues](https://github.com/JJ/hoborg/issues), any other business, just
+issues](https://github.com/JJ/hoborg/issues). For any other business, just
 [email me](mailto:hoborg@merelo.net).

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ You already know the [text](text/README.md) directory, which contains
 the novel text itself as well as scraps we might need for
 later. [resources](resources/README.md) contains HTML templates,
 images and other non-text stuff. [apps](apps/README.md) includes
-conversion scripts and other scripts I use for managing
-this, mainly written in Perl. [Text-Hoborg](Text-Hoborg/README) contains a Perl module that is
+conversion scripts and other mainly Perl scripts I use for managing
+this. [Text-Hoborg](Text-Hoborg/README) contains a Perl module that is
 used for testing and continuous integration and might eventually
 contain the novel itself and be released that way. 
 


### PR DESCRIPTION
Typos
-'al' -> 'an'
-'inmediately' -> 'immediately'

Grammatical Errors
-'that' -> 'who' - Subject are humans
-',' -> '. For' - Separate topics and so it should be separated

Word Choices
-'worth the while' -> 'worth your while' - 'Worth the while' is used in more traditional writing, but writing today uses 'worth your while' so that the writing is more personal
-'spoilerage' -> 'spoiling the story for yourself' - Formality

Line 60-62
-Added 'while' - Contrasting two things
-Removed 'it' and added 'is' - 'published it' is in active voice and requires a subject. 'is published' changes to passive voice and requires no subject